### PR TITLE
[improve] Added string-storage in GLabeloperations

### DIFF
--- a/c/src/gobjects.c
+++ b/c/src/gobjects.c
@@ -634,7 +634,7 @@ GLabel newGLabel(string str) {
    label = newGObject(GLABEL);
    label->u.labelRep.str = str;
    label->u.labelRep.font = DEFAULT_GLABEL_FONT;
-   createGLabelOp(label, copyString(str));
+   createGLabelOp(label, str);
    setFont(label, DEFAULT_GLABEL_FONT);
    return label;
 }
@@ -659,7 +659,7 @@ void setLabel(GLabel label, string str) {
    GDimension size;
 
    label->u.labelRep.str = str;
-   setLabelOp(label, copyString(str));
+   setLabelOp(label, str);
    size = getGLabelSizeOp(label);
    label->width = size.width;
    label->height = size.height;

--- a/c/src/platform.c
+++ b/c/src/platform.c
@@ -947,9 +947,12 @@ void setSweepAngleOp(GArc arc, double angle) {
 /* GLabel operations */
 
 void createGLabelOp(GLabel label, string str) {
-   str = quotedString(str);
-   putPipe("GLabel.create(\"0x%lX\", %s)", (long) label, str);
-   freeBlock(str);
+   string tmp;
+
+   tmp = copyString(str);
+   tmp = quotedString(tmp);
+   putPipe("GLabel.create(\"0x%lX\", %s)", (long) label, tmp);
+   freeBlock(tmp);
 }
 
 void setFontOp(GLabel label, string font) {
@@ -957,9 +960,12 @@ void setFontOp(GLabel label, string font) {
 }
 
 void setLabelOp(GLabel label, string str) {
-   str = quotedString(str);
-   putPipe("GLabel.setLabel(\"0x%lX\", %s)", (long) label, str);
-   freeBlock(str);
+   string tmp;
+
+   tmp = copyString(str);
+   tmp = quotedString(tmp);
+   putPipe("GLabel.setLabel(\"0x%lX\", %s)", (long) label, tmp);
+   freeBlock(tmp);
 }
 
 double getFontAscentOp(GLabel label) {


### PR DESCRIPTION
Fixed ugly implementation of `createGLabelOp` and `setLabelOp` in platform.c.